### PR TITLE
Explicitly set key and keyserver, so we don't make a request to get.dock...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,7 +105,8 @@ default['docker']['package']['repo_url'] = value_for_platform(
   },
   'default' => nil
 )
-default['docker']['package']['repo_key'] = 'https://get.docker.io/gpg'
+default['docker']['package']['repo_keyserver'] = 'keyserver.ubuntu.com'
+default['docker']['package']['repo_key'] = 'A88D21E9'
 
 ## Source installation attributes
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -18,6 +18,7 @@ when 'debian', 'ubuntu'
       uri node['docker']['package']['repo_url']
       distribution node['docker']['package']['distribution']
       components ['main']
+      keyserver node['docker']['package']['repo_keyserver']
       key node['docker']['package']['repo_key']
     end
   end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -16,7 +16,8 @@ shared_examples_for 'an apt-based system' do
       uri: 'https://get.docker.io/ubuntu',
       distribution: 'docker',
       components: ['main'],
-      key: 'https://get.docker.io/gpg'
+      keyserver: 'keyserver.ubuntu.com',
+      key: 'A88D21E9'
     )
   end
 


### PR DESCRIPTION
...er.io on every chef run.
